### PR TITLE
Simplify address matching by providing a Matcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ lints = ["clippy"]
 byteorder = "1"
 clippy = {version="^0", optional=true}
 regex = "1.5"
+nom = "7"

--- a/src/address.rs
+++ b/src/address.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 
 /// With a Matcher OSC method addresses can be [matched](Matcher::match_address) against an OSC address pattern.
 /// Refer to the OSC specification for details about OSC address spaces: <http://opensoundcontrol.org/spec-1_0.html#osc-address-spaces-and-osc-addresses>
+#[derive(Debug)]
 pub struct Matcher {
     res: Vec<Regex>,
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,174 +1,131 @@
 use crate::errors::OscError;
-use crate::regex::Regex;
-use crate::types::Result;
 
-fn validate_address(addr: &str) -> Result<()> {
-    if !addr.is_ascii() {
-        return Err(OscError::BadAddress(
-            "Address must only contain ASCII characters",
-        ));
-    }
-    if addr.is_empty() {
-        return Err(OscError::BadAddress(
-            "Address must be at least 1 character long",
-        ));
-    }
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag};
+use nom::character::complete::char;
+use nom::combinator::{all_consuming, map_parser};
+use nom::multi::many1;
+use nom::sequence::{delimited, preceded};
+use nom::{IResult, Parser};
+use regex::Regex;
 
-    // Check if address starts with '/'
-    if !addr.starts_with('/') {
-        return Err(OscError::BadAddress("Address must start with '/'"));
-    }
-
-    // Check if address ends with '/'
-    if addr.ends_with('/') {
-        return Err(OscError::BadAddress("Address must not end with '/'"));
-    }
-
-    Ok(())
+/// With a Matcher OSC method addresses can be [matched](Matcher::match_address) against an OSC address pattern.
+/// Refer to the OSC specification for details about OSC address spaces: <http://opensoundcontrol.org/spec-1_0.html#osc-address-spaces-and-osc-addresses>
+pub struct Matcher {
+    res: Vec<Regex>,
 }
 
-/// Check if the address of an OSC method is valid
-pub fn validate_method_address(addr: &str) -> Result<()> {
-    match validate_address(addr) {
-        Ok(()) => {}
-        Err(e) => return Err(e),
+impl Matcher {
+
+    /// Instantiates a new `Matcher` with the given address pattern.
+    /// An error will be returned if the given address pattern is invalid.
+    /// 
+    /// Matcher should be instantiated once per pattern and reused because its construction requires parsing the address pattern which is computationally expensive.
+    ///
+    /// A valid address pattern begins with a `/` and contains at least a method name, e.g. `/tempo`.
+    /// OSC defines a couple of rules that look like regular expression but are subtly different:
+    ///
+    /// - `?` matches a single character
+    /// - `*` matches zero or more characters
+    /// - `[a-z]` are basically regex [character classes](https://www.regular-expressions.info/charclass.html)
+    /// - `{foo,bar}` is an alternative, matching either `foo` or `bar`
+    /// - everything else is matches literally
+    /// 
+    /// Refer to the OSC specification for details about address pattern matching: <osc-message-dispatching-and-pattern-matching>.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use rosc::address::Matcher;
+    /// 
+    /// Matcher::new("/tempo").expect("valid address");
+    /// Matcher::new("").expect_err("address does not start with a slash");
+    /// ```
+    pub fn new(pattern: &str) -> Result<Self, OscError> {
+        let res = parse_address_pattern(pattern)?;
+        Ok(Matcher { res: res })
     }
 
-    let chars = addr.chars();
-
-    // Check if address contains illegal characters
-    for char in chars {
-        match char {
-            _c if ((char as u8) < 0x20) | ((char as u8) > 0x7E) => {
-                return Err(OscError::BadAddress(
-                    "Address may only contain printable ASCII characters",
-                ));
-            }
-            _c if " #*,?[]{}".chars().any(|x| char == x) => {
-                return Err(OscError::BadAddress(
-                    "Address may not contain any of the following characters: ' #*,?[]{}'",
-                ));
-            }
-            _ => (),
-        }
-    }
-
-    Ok(())
-}
-
-/// Check if the address of an OSC message is valid
-pub fn validate_message_address(addr: &str) -> Result<()> {
-    match validate_address(addr) {
-        Ok(()) => {}
-        Err(e) => return Err(e),
-    }
-
-    let chars = addr.chars();
-
-    // Validate rest of address
-    let mut in_character_range = false;
-    let mut in_string_list = false;
-    for char in chars {
-        if ((char as u8) < 0x20) | ((char as u8) > 0x7E) {
-            return Err(OscError::BadAddress(
-                "Address may only contain printable ASCII characters",
-            ));
-        }
-        if " #".chars().any(|x| char == x) {
-            return Err(OscError::BadAddress(
-                "Address may not contain any of the following characters: ' #'",
-            ));
-        }
-        if !in_string_list && char == ',' {
-            return Err(OscError::BadAddress("Address may not contain any of the following characters outside of string lists: ','"));
-        }
-        if char == '[' {
-            in_character_range = true;
-            if in_string_list {
-                return Err(OscError::BadAddress("Can not start a character range (square brackets) within string list (curly brackets)"));
-            }
-        }
-        if (char == '/') & in_character_range {
-            return Err(OscError::BadAddress("Character range (square brackets) was started but not closed before the next address part started"));
-        }
-        if char == ']' {
-            in_character_range = false;
-        }
-        if char == '{' {
-            in_string_list = true;
-        }
-        if (char == '/') & in_string_list {
-            return Err(OscError::BadAddress("String list (curly brackets) was started but not closed before the next address part started"));
-        }
-        if char == '}' {
-            in_string_list = false;
-            if in_character_range {
-                return Err(OscError::BadAddress("Can not start a string list (curly brackets) within character range (square brackets)"));
-            }
-        }
-    }
-    if in_character_range {
-        return Err(OscError::BadAddress("Character range (square brackets) was started but not closed before the end of the address"));
-    }
-    if in_string_list {
-        return Err(OscError::BadAddress(
-            "String list (curly brackets) was started but not closed before the end of the address",
-        ));
-    }
-
-    Ok(())
-}
-
-/// Match a single part of two OSC addresses
-fn match_part(message_part: &str, method_part: &str) -> bool {
-    // direct match
-    if message_part == method_part {
-        return true;
-    }
-
-    // Use regex for everything else
-    let mut pattern = message_part
-        .to_string()
-        .replace("*", "\\w*")
-        .replace("?", "\\w")
-        .replace("[!", "[^")
-        .replace(",", ")|(?:")
-        .replace("{", "(?:")
-        .replace("}", ")");
-
-    // Anchor the pattern to beginning and end of string
-    pattern = format!("^{}$", pattern);
-
-    let re = Regex::new(pattern.as_str()).unwrap();
-
-    re.is_match(method_part)
-}
-
-/// Check if a message address matches a method address
-pub fn match_address(message_addr: &str, method_addr: &str) -> Result<bool> {
-    match validate_message_address(message_addr) {
-        Ok(()) => {}
-        Err(e) => return Err(e),
-    }
-    match validate_method_address(method_addr) {
-        Ok(()) => {}
-        Err(e) => return Err(e),
-    }
-
-    let message_addr_parts: Vec<&str> = message_addr.split('/').collect();
-    let method_addr_parts: Vec<&str> = method_addr.split('/').collect();
-
-    if message_addr_parts.len() != method_addr_parts.len() {
-        // Both addresses must have the same amount of parts
-        return Ok(false);
-    }
-
-    for i in 1..message_addr_parts.len() {
-        //println!("Parts: '{}' '{}' {}", message_addr_parts[i], method_addr_parts[i], match_part(message_addr_parts[i], method_addr_parts[i]));
-        if !match_part(message_addr_parts[i], method_addr_parts[i]) {
+    /// Match an OSC address against an address pattern.
+    /// If the address matches the pattern the result will be `true`, otherwise `false`.
+    /// An error is returned if the given OSC address is not valid.
+    /// 
+    /// A valid OSC address begins with a `/` and contains at least a method name, e.g. `/tempo`.
+    /// Despite OSC address patterns a plain address must not include any of the following characters `#*,/?[]{}`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use rosc::address::Matcher;
+    /// 
+    /// let matcher = Matcher::new("/oscillator/[0-9]/{frequency,phase}").unwrap();
+    /// assert!(matcher.match_address("/oscillator/1/frequency").unwrap());
+    /// assert!(matcher.match_address("/oscillator/8/phase").unwrap());
+    /// assert_eq!(matcher.match_address("/oscillator/4/detune").unwrap(), false);
+    /// ```
+    pub fn match_address(&self, address: &str) -> Result<bool, OscError> {
+        let (_, parts) = all_consuming(many1(parse_address_part))(address)
+            .map_err(|_| OscError::BadAddress("bad address".to_string()))?;
+        if parts.len() != self.res.len() {
             return Ok(false);
         }
+        Ok(self
+            .res
+            .iter()
+            .zip(parts)
+            .all(|(re, part)| re.is_match(part)))
     }
+}
 
-    Ok(true)
+fn map_alternative(s: &str) -> String {
+    wrap_with(&s.replace(',', "|"), "(", ")")
+}
+
+fn wrap_with(s: &str, pre: &str, post: &str) -> String {
+    pre.to_string() + s + post.into()
+}
+
+fn map_wildcard(_: &str) -> String {
+    r"\w*".into()
+}
+
+fn map_question_mark(_: &str) -> String {
+    r"\w?".into()
+}
+
+fn parse_address_part(input: &str) -> IResult<&str, &str> {
+    // TODO: the second parser, is_not, should require a non empty match
+    preceded(char('/'), is_not(" \t\r\n#*,/?[]{}"))(input)
+}
+
+fn parse_address_pattern_part(input: &str) -> IResult<&str, &str> {
+    // TODO: the second parser, is_not, should require a non empty match
+    preceded(char('/'), is_not(" \n\t\r/"))(input)
+}
+
+// Translate OSC pattern rules into an regular expression.
+// A pattern part can contain more than one rule, e.g. `{voice,synth}-[1-9]` contains two rules, an alternative and a number range.
+fn parse_pattern_part(input: &str) -> IResult<&str, String> {
+    many1(alt((
+        delimited(char('{'), is_not("}"), char('}')).map(map_alternative),
+        delimited(tag("[!"), is_not("]"), char(']')).map(|s: &str| wrap_with(s, "[^", "]")),
+        delimited(char('['), is_not("]"), char(']')).map(|s: &str| wrap_with(s, "[", "]")),
+        tag("*").map(map_wildcard),
+        tag("?").map(map_question_mark),
+        is_not("[{").map(|s: &str| s.to_owned()),
+    )))(input)
+    .map(|(input, parts)| (input, parts.concat()))
+}
+
+fn parse_address_pattern(input: &str) -> Result<Vec<Regex>, OscError> {
+    let (_, patterns) = all_consuming(many1(map_parser(
+        parse_address_pattern_part,
+        parse_pattern_part,
+    )))(input)
+    .map_err(|_| OscError::BadAddressPattern("bad address pattern".to_string()))?;
+    patterns
+        .iter()
+        .map(|p| Regex::new(p))
+        .collect::<Result<Vec<Regex>, regex::Error>>()
+        .map_err(|err| OscError::RegexError(err.to_string()))
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,11 +6,13 @@ pub enum OscError {
     StringError(string::FromUtf8Error),
     ReadError(io::Error),
     BadPacket(&'static str),
-    BadAddress(&'static str),
     BadMessage(&'static str),
     BadString(&'static str),
     BadArg(String),
     BadBundle(String),
+    BadAddressPattern(String),
+    BadAddress(String),
+    RegexError(String),
     Unimplemented,
 }
 
@@ -19,12 +21,14 @@ impl fmt::Display for OscError {
         match self {
             OscError::StringError(err) => write!(f, "reading OSC string as utf-8: {}", err),
             OscError::ReadError(err) => write!(f, "reading from buffer: {}", err),
-            OscError::BadPacket(msg) => write!(f, "{}", msg),
-            OscError::BadAddress(msg) => write!(f, "{}", msg),
+            OscError::BadPacket(msg) => write!(f, "bad OSC packet: {}", msg),
             OscError::BadMessage(msg) => write!(f, "bad OSC message: {}", msg),
             OscError::BadString(msg) => write!(f, "bad OSC string: {}", msg),
             OscError::BadArg(msg) => write!(f, "bad OSC argument: {}", msg),
             OscError::BadBundle(msg) => write!(f, "bad OSC bundle: {}", msg),
+            OscError::BadAddressPattern(msg) => write!(f, "bad OSC address pattern: {}", msg),
+            OscError::BadAddress(msg) => write!(f, "bad OSC address: {}", msg),
+            OscError::RegexError(msg) => write!(f, "OSC address pattern regex error: {}", msg),
             OscError::Unimplemented => write!(f, "unimplemented"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate byteorder;
 extern crate regex;
+extern crate nom;
 
 /// Crate specific error types.
 mod errors;

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,267 +1,46 @@
 extern crate rosc;
 
-use rosc::{address, OscError};
+use rosc::{OscError, address::Matcher};
 
 #[test]
-fn test_validate_method_address() {
-    // Valid addresses
-    address::validate_method_address(&String::from("/")).expect("");
-    address::validate_method_address(&String::from("/a")).expect("");
-
-    // Invalid addresses
-    match address::validate_method_address(&String::from("/foo\0"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address may only contain printable ASCII characters") => {
-            assert!(true)
-        }
-        _ => assert!(false),
-    }
-    match address::validate_method_address(&String::from("öäü"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must only contain ASCII characters") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_method_address(&String::from(""))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must be at least 1 character long") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_method_address(&String::from("foo"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must start with '/'") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_method_address(&String::from("/foo/"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must not end with '/'") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_method_address(&String::from("/ illegal#*,?[]{}"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(
-            "Address may not contain any of the following characters: ' #*,?[]{}'",
-        ) => assert!(true),
-        _ => assert!(false),
-    }
+fn test_matcher() {
+    let matcher = Matcher::new("/oscillator/[0-9]/*/pre[!1234?*]post/{frequency,phase}/x?")
+        .expect("Matcher::new");
+    assert_eq!(
+        matcher
+            .match_address("/oscillator/1/something/preXpost/phase/xy")
+            .expect("should match"),
+        true
+    );
+    assert_eq!(
+        matcher
+            .match_address("/oscillator/1/something/pre1post/phase/xy")
+            .expect("should not match"),
+        false
+    );
+    matcher.match_address("invalid_address").expect_err("should fail because address does not start with a slash");
 }
 
 #[test]
-fn test_validate_message_address() {
-    // Valid addresses
-    address::validate_message_address(&String::from("/a")).expect("");
-    address::validate_message_address(&String::from("/a[!a-z]")).expect("");
-    address::validate_message_address(&String::from("/a{foo,bar}")).expect("");
-    address::validate_message_address(&String::from("/a?/foo*/bar")).expect("");
-
-    // Invalid addresses
-    match address::validate_message_address(&String::from("/foo\0"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address may only contain printable ASCII characters") => {
-            assert!(true)
-        }
-        _ => assert!(false),
-    }
-    match address::validate_message_address(&String::from("öäü"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must only contain ASCII characters") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_message_address(&String::from(""))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must be at least 1 character long") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_message_address(&String::from("foo"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must start with '/'") => assert!(true),
-        _ => assert!(false),
-    }
-    match address::validate_message_address(&String::from("/foo/"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress("Address must not end with '/") => assert!(true),
-        _ => assert!(false),
-    }
-
-    // Square brackets open and never close
-    match address::validate_message_address(&String::from("/[a/b")).err().expect("") {
-        OscError::BadAddress("Character range (square brackets) was started but not closed before the next address part started") => assert!(true),
-        _ => assert!(false)
-    }
-    // Square brackets contains /
-    match address::validate_message_address(&String::from("/[a/]b")).err().expect("") {
-        OscError::BadAddress("Character range (square brackets) was started but not closed before the next address part started") => assert!(true),
-        _ => assert!(false)
-    }
-    // Square brackets open but don't close before the address ends
-    match address::validate_message_address(&String::from("/[a")).err().expect("") {
-        OscError::BadAddress("Character range (square brackets) was started but not closed before the end of the address") => assert!(true),
-        _ => assert!(false)
-    }
-
-    // Curly brackets open and never close
-    match address::validate_message_address(&String::from("/{a/b")).err().expect("") {
-        OscError::BadAddress("String list (curly brackets) was started but not closed before the next address part started") => assert!(true),
-        _ => assert!(false)
-    }
-    // Curly brackets contains /
-    match address::validate_message_address(&String::from("/{a/}b")).err().expect("") {
-        OscError::BadAddress("String list (curly brackets) was started but not closed before the next address part started") => assert!(true),
-        _ => assert!(false)
-    }
-    // Curly brackets open but don't close before the address ends
-    match address::validate_message_address(&String::from("/{a"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(
-            "String list (curly brackets) was started but not closed before the end of the address",
-        ) => assert!(true),
-        _ => assert!(false),
-    }
-
-    // Curly brackets within square brackets
-    match address::validate_message_address(&String::from("/{a[foo]}/"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(
-            "Can not start a character range (square brackets) within string list (curly brackets)",
-        ) => assert!(true),
-        _ => assert!(false),
-    }
-
-    // Square brackets within curly brackets
-    match address::validate_message_address(&String::from("/[a{foo}]/"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(
-            "Can not start a string list (curly brackets) within character range (square brackets)",
-        ) => assert!(true),
-        _ => assert!(false),
-    }
+fn test_bad_address_pattern() {
+    let expected_err = "bad OSC address pattern: bad address pattern";
+    assert_eq!(Matcher::new("").unwrap_err().to_string(), expected_err);
+    assert_eq!(Matcher::new("/").unwrap_err().to_string(), expected_err);
+    assert_eq!(Matcher::new("//empty/parts/").unwrap_err().to_string(), expected_err); // FIX: will fail
+    assert_eq!(Matcher::new("////").unwrap_err().to_string(), expected_err);
+    assert_eq!(Matcher::new("/{unclosed,alternative").unwrap_err().to_string(), expected_err);
+    assert_eq!(Matcher::new("/unclosed/[range-").unwrap_err().to_string(), expected_err);
 }
 
 #[test]
-pub fn test_match_address() {
-    // Test invalid message and method address
-    match address::match_address(&String::from("asd"), &String::from("/foo"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(_) => assert!(true),
-        _ => assert!(false),
-    }
-    // Test invalid message address
-    match address::match_address(&String::from("/foo"), &String::from("asd"))
-        .err()
-        .expect("")
-    {
-        OscError::BadAddress(_) => assert!(true),
-        _ => assert!(false),
-    }
-
-    // Trivial match
-    assert!(address::match_address(&String::from("/foo"), &String::from("/foo")).expect(""));
-    assert!(
-        address::match_address(&String::from("/foo/bar"), &String::from("/foo/bar")).expect("")
-    );
-
-    // Match with wildcard
-    assert!(address::match_address(&String::from("/foo/*"), &String::from("/foo/bar")).expect(""));
-    assert!(address::match_address(
-        &String::from("/foo/b*r"),
-        &String::from("/foo/baaaaaaaaaaaar")
-    )
-    .expect(""));
-    assert!(address::match_address(
-        &String::from("/foo/b*r"),
-        &String::from("/foo/barxxxxxxxxxxr")
-    )
-    .expect(""));
-    assert!(address::match_address(
-        &String::from("/foo/b*r/baz"),
-        &String::from("/foo/baaaaaaaaaaaar/baz")
-    )
-    .expect(""));
-
-    // Single character wildcard
-    assert!(
-        address::match_address(&String::from("/foo/b?r"), &String::from("/foo/bar")).expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/b???r"), &String::from("/foo/baaar")).expect("")
-    );
-
-    // Combine wildcards
-    assert!(
-        address::match_address(&String::from("/foo/b?*?r"), &String::from("/foo/baar")).expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/b?*?r"), &String::from("/foo/baaaar"))
-            .expect("")
-    );
-
-    // String lists
-    assert!(
-        address::match_address(&String::from("/foo/{bar,baz}"), &String::from("/foo/bar"))
-            .expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/{bar,baz}"), &String::from("/foo/baz"))
-            .expect("")
-    );
-    assert!(
-        !address::match_address(&String::from("/foo/{bar,baz}"), &String::from("/foo/bot"))
-            .expect("")
-    );
-
-    // Character ranges
-    assert!(
-        address::match_address(&String::from("/foo/b[a-c]r"), &String::from("/foo/bar")).expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/b[a-c]r"), &String::from("/foo/bbr")).expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/b[a-c]r"), &String::from("/foo/bcr")).expect("")
-    );
-    assert!(
-        address::match_address(&String::from("/foo/b[!a-c]r"), &String::from("/foo/bdr"))
-            .expect("")
-    );
-
-    // Test that address part matches full address, not just a subset, when using regex
-    assert!(
-        address::match_address(&String::from("/foo/b[ab]r"), &String::from("/foo/bar")).expect("")
-    );
-    assert!(
-        !address::match_address(&String::from("/foo/b[ab]r"), &String::from("/foo/barasd"))
-            .expect("")
-    );
-    assert!(
-        !address::match_address(&String::from("/foo/a?d"), &String::from("/foo/barasd")).expect("")
-    );
+fn test_bad_address() {
+    let matcher = Matcher::new("/does-not-matter").expect("Matcher::new");
+    let expected_err = "bad OSC address: bad address";
+    assert_eq!(matcher.match_address("").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/contains/wildcards?").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/contains/wildcards*").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/contains/ranges[a-z]").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/contains/ranges[!a-z]").unwrap_err().to_string(), expected_err);
+    assert_eq!(matcher.match_address("/{contains,alternative}").unwrap_err().to_string(), expected_err);
 }

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -26,7 +26,7 @@ fn test_bad_address_pattern() {
     let expected_err = "bad OSC address pattern: bad address pattern";
     assert_eq!(Matcher::new("").unwrap_err().to_string(), expected_err);
     assert_eq!(Matcher::new("/").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("//empty/parts/").unwrap_err().to_string(), expected_err); // FIX: will fail
+    assert_eq!(Matcher::new("//empty/parts/").unwrap_err().to_string(), expected_err);
     assert_eq!(Matcher::new("////").unwrap_err().to_string(), expected_err);
     assert_eq!(Matcher::new("/{unclosed,alternative").unwrap_err().to_string(), expected_err);
     assert_eq!(Matcher::new("/unclosed/[range-").unwrap_err().to_string(), expected_err);


### PR DESCRIPTION
A Matcher is constructed from an OSC address pattern and will use a
number of precompiled regular expression to match against a concrete OSC
address.  Regular expression match quite well to the pattern rules given
by the OSC specification and are used by other popular OSC libraries for
this purpose, e.g. [python-osc][1].

I chose `nom` as a parser combinator library to parse OSC addresses and
OSC address patterns reliably and efficiently.

@DrLuke please do not take this as a criticism of your implementation, I
am very about happy your contribution!  Actually, I would be happy if
_you_ could review this change so we can merge it back into your PR and
eventually release this feature.

My GitHub feed showed me that @D1plo1d is working on a [`no_std`
feature][2] which also adds `nom`.  I would be happy to receive a review
from @D1plo1d as well, hoping to reduce merge conflicts with their
feature.

Please be kind, I haven't programmed Rust in a long time and never used
`nom` before.

[1]: https://github.com/attwad/python-osc
[2]: https://github.com/D1plo1d/rosc/tree/feature/no_std